### PR TITLE
New filters + filter summary

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,8 @@
 {
     "prefix": "??",
     "considerationPeriod": 15000,
-    "topNEntries": 5,
+    "maxEntriesLimit": 15,
+    "defaultEntriesLimit": 5,
     "logChannel": "",
     "statusInterval": 60000,
     "reactToCommands": true,

--- a/config/config.json
+++ b/config/config.json
@@ -2,7 +2,7 @@
     "prefix": "??",
     "considerationPeriod": 15000,
     "maxEntriesLimit": 15,
-    "defaultEntriesLimit": 5,
+    "defaultEntriesLimit": 10,
     "logChannel": "",
     "statusInterval": 60000,
     "reactToCommands": true,

--- a/lib/commands/emotes.js
+++ b/lib/commands/emotes.js
@@ -2,7 +2,7 @@ const Constants = require("../core/Constants");
 const { defaultEntriesLimit, maxEntriesLimit, prefix } = require("../../config/config.json");
 const _ = require("lodash");
 const logger = require("../core/Logger.js");
-const { timestampFromId } = require("../core/Utils");
+const { timestampFromId, dehumanizeTime } = require("../core/Utils");
 const filterRegexes = {
     guild: {
         multiple: true,
@@ -56,6 +56,14 @@ const filterRegexes = {
         multiple: false,
         regexes: [
             { regex: /since:([1-9][0-9]{0,19})/g, onMatch: match => Math.floor(timestampFromId(match[1])) },
+            { regex: /last:(\d+\w+)/g, onMatch: match => {
+                    const n = dehumanizeTime(match[1]);
+                    if (n < 0) return;
+                    const result = Date.now() - n;
+                    if (result < 1420070400000) return; // 1420070400000 is the Discord epoch
+                    return result;
+                }
+            },
         ],
     },
 };

--- a/lib/commands/emotes.js
+++ b/lib/commands/emotes.js
@@ -2,15 +2,17 @@ const Constants = require("../core/Constants");
 const { defaultEntriesLimit, maxEntriesLimit, prefix, developerIDs } = require("../../config/config.json");
 const _ = require("lodash");
 const logger = require("../core/Logger.js");
-const { timestampFromId, dehumanizeTime } = require("../core/Utils");
+const { timestampFromId, dehumanizeTime, humanizeTime } = require("../core/Utils");
 const filterRegexes = {
     guild: {
+        name: "server",
         multiple: true,
         regexes: [
             { regex: /(?:server|guild):([1-9][0-9]{0,19})/ig, onMatch: match => match[1] },
             { regex: /(?:server|guild):here/ig, onMatch: match => "here" },
             { regex: /(?:server|guild):all/ig, onMatch: match => "all" },
         ],
+        valueMapper: value => value.join(", "),
     },
     user: {
         multiple: true,
@@ -19,6 +21,7 @@ const filterRegexes = {
             { regex: /user:me/ig, onMatch: match => "me" },
             { regex: /<@!?([1-9][0-9]{0,19})>/ig, onMatch: match => match[1] },
         ],
+        valueMapper: value => value.map(v => `<@!${v}>`).join(", "),
     },
     emote: {
         multiple: true,
@@ -27,18 +30,21 @@ const filterRegexes = {
             { regex: Constants.CUSTOM_REGEX, onMatch: match => match[3] },
             { regex: new RegExp(`(${Constants.UNICODE_REGEX.source})`, "ug"), onMatch: match => match[2] ? undefined : match[1] },
         ],
+        valueMapper: value => value.join(", "),
     },
     duplicate: {
         multiple: false,
         regexes: [
             { regex: /duplicate:(no?|ye?s?)/ig, onMatch: match => match[1].toLowerCase().startsWith("n") ? false : true },
         ],
+        valueMapper: value => value ? "Yes" : "No",
     },
     order: {
         multiple: false,
         regexes: [
             { regex: /order:(as?c?e?n?d?i?n?g?|de?s?c?e?n?d?i?n?g?)/ig, onMatch: match => match[1].toLowerCase().startsWith("a") ? true : false },
         ],
+        valueMapper: value => value ? "Ascending" : "Descending",
     },
     limit: {
         multiple: false,
@@ -50,6 +56,7 @@ const filterRegexes = {
                 }
             },
         ],
+        valueMapper: value => value.toString(),
     },
     since: {
         multiple: false,
@@ -64,12 +71,14 @@ const filterRegexes = {
                 }
             },
         ],
+        valueMapper: value => humanizeTime(Date.now() - value) + " ago",
     },
     visibility: {
         multiple: false,
         regexes: [
             { regex: /visibility:(global|visible|server)/ig, onMatch: match => match[1].toLowerCase() },
         ],
+        valueMapper: value => value.charAt(0).toUpperCase() + value.slice(1),
     },
 };
 const defaultFilters = { duplicate: true, order: false, limit: defaultEntriesLimit, visibility: 'global' };
@@ -126,9 +135,10 @@ If you do not provide a filter for either a server or a user and:
             const totalEntries = _.sumBy(entries, x => x[1]);
 
             if (entries.length > 0) {
+                const filtersRecap = getFiltersRecap(filters);
                 const description = emoteDataToGraph(entries, totalEntries, 5);
                 
-                embed = { title: "Results", color: 0x00ff00, description };
+                embed = { color: 0x00ff00, description: filtersRecap, fields: [{ name: "Results", value: description, inline: false }] };
                 if (groupBy === "emote") {
                     embed.footer = { text: "If an emote isn't displayed, it's because I don't have access to it." };
                 }
@@ -139,6 +149,27 @@ If you do not provide a filter for either a server or a user and:
         }
         m.channel.createMessage(response);
     }
+}
+
+/**
+ * Outputs a string which recaps the used filters
+ *  Will ignore any filter set to the default value whether it was specified by the user or not
+ * 
+ * @param {Filters} filters The filters to recap
+ * @returns {string} The resulting string
+ */
+function getFiltersRecap(filters) {
+    const strings = [];
+    const keys = Object.keys(filters);
+    for (const filter of keys) {
+        const value = filters[filter];
+        const label = filterRegexes[filter].name || filter;
+        if (value !== defaultFilters[filter]) {
+            strings.push(`${label.charAt(0).toUpperCase() + label.slice(1)}: ${filterRegexes[filter].valueMapper(value)}`);
+        }
+    }
+    strings.sort();
+    return strings.join("\n");
 }
 
 /**

--- a/lib/commands/emotes.js
+++ b/lib/commands/emotes.js
@@ -7,10 +7,8 @@ const filterRegexes = {
     guild: {
         multiple: true,
         regexes: [
-            { regex: /server:([1-9][0-9]{0,19})/ig, onMatch: match => match[1] },
-            { regex: /server:here/ig, onMatch: match => "here" },
-            { regex: /guild:([1-9][0-9]{0,19})/ig, onMatch: match => match[1] },
-            { regex: /guild:here/ig, onMatch: match => "here" },
+            { regex: /(?:server|guild):([1-9][0-9]{0,19})/ig, onMatch: match => match[1] },
+            { regex: /(?:server|guild):here/ig, onMatch: match => "here" },
         ],
     },
     user: {

--- a/lib/commands/emotes.js
+++ b/lib/commands/emotes.js
@@ -3,27 +3,43 @@ const { topNEntries } = require("../../config/config.json");
 const _ = require("lodash");
 const logger = require("../core/Logger.js");
 const filterRegexes = {
-    guild: [
-        { regex: /server:([1-9][0-9]{0,19})/g, onMatch: match => match[1] },
-        { regex: /server:here/g, onMatch: match => "here" },
-        { regex: /guild:([1-9][0-9]{0,19})/g, onMatch: match => match[1] },
-        { regex: /guild:here/g, onMatch: match => "here" },
-    ],
-    user: [
-        { regex: /user:([1-9][0-9]{0,19})/g, onMatch: match => match[1] },
-        { regex: /user:me/g, onMatch: match => "me" },
-        { regex: /<@!?([1-9][0-9]{0,19})>/g, onMatch: match => match[1] },
-    ],
-    emote: [
-        { regex: /emote:([1-9][0-9]{0,19})/g, onMatch: match => match[1] },
-        { regex: Constants.CUSTOM_REGEX, onMatch: match => match[3] },
-        { regex: new RegExp(`(${Constants.UNICODE_REGEX.source})`, "ug"), onMatch: match => match[2] ? false : match[1] },
-    ],
+    guild: {
+        multiple: true,
+        regexes: [
+            { regex: /server:([1-9][0-9]{0,19})/g, onMatch: match => match[1] },
+            { regex: /server:here/g, onMatch: match => "here" },
+            { regex: /guild:([1-9][0-9]{0,19})/g, onMatch: match => match[1] },
+            { regex: /guild:here/g, onMatch: match => "here" },
+        ],
+    },
+    user: {
+        multiple: true,
+        regexes: [
+            { regex: /user:([1-9][0-9]{0,19})/g, onMatch: match => match[1] },
+            { regex: /user:me/g, onMatch: match => "me" },
+            { regex: /<@!?([1-9][0-9]{0,19})>/g, onMatch: match => match[1] },
+        ],
+    },
+    emote: {
+        multiple: true,
+        regexes: [
+            { regex: /emote:([1-9][0-9]{0,19})/g, onMatch: match => match[1] },
+            { regex: Constants.CUSTOM_REGEX, onMatch: match => match[3] },
+            { regex: new RegExp(`(${Constants.UNICODE_REGEX.source})`, "ug"), onMatch: match => match[2] ? undefined : match[1] },
+        ],
+    },
+    duplicate: {
+        multiple: false,
+        regexes: [
+            { regex: /duplicate:(no?|ye?s?)/, onMatch: match => match[1] && match[1].startsWith("n") ? false : true },
+        ],
+    },
 };
+const defaultFilters = { duplicate: true };
 
 /**
  * Filters for emote database requests
- * @typedef {{user: ?string[], guild: ?string[], emote: ?string[]}} Filters
+ * @typedef {{user: ?string[], guild: ?string[], emote: ?string[], duplicate: boolean}} Filters
  */
 
 module.exports = {
@@ -44,6 +60,7 @@ __**Available filters**__
     \`emote:id\` --> \`id\` is the id of a custom emote
     You can also directly use any emote, custom or not, to filter by it
         Example: \`🤔 :emote:\` (assuming you have access to an emote named 'emote')
+    \`duplicate:no\` --> doesn't count duplicate emotes in messages
 
 Using multiple filters of the same category will keep any of the given values.
     Example: \`user:me @Someone#1234\` --> entries for me or Someone#1234
@@ -247,17 +264,22 @@ function fixFilters(filters, message) {
  * @returns {Filters}
  */
 function parseFilters(args) {
-    const filters = {};
+    const filters = { ...defaultFilters };
     for (const arg of args) {
         let matched = false;
-        for (let [filter, regexes] of Object.entries(filterRegexes)) {
+        for (let [filterName, filter] of Object.entries(filterRegexes)) {
+            const { multiple, regexes } = filter;
             for (const { regex, onMatch } of regexes) {
                 let match = regex.exec(arg);
                 if (match) {
                     const value = onMatch(match);
-                    if (value !== false) {
-                        filters[filter] = filters[filter] || [];
-                        filters[filter].push(value);
+                    if (value !== undefined) {
+                        if (multiple) {
+                            filters[filterName] = filters[filterName] || [];
+                            filters[filterName].push(value);
+                        } else {
+                            filters[filterName] = value;
+                        }
                         matched = true;
                     }
                 }

--- a/lib/commands/emotes.js
+++ b/lib/commands/emotes.js
@@ -66,8 +66,14 @@ const filterRegexes = {
             },
         ],
     },
+    visibility: {
+        multiple: false,
+        regexes: [
+            { regex: /visibility:(global|visible|server)/g, onMatch: match => match[1] },
+        ],
+    },
 };
-const defaultFilters = { duplicate: true, order: false, limit: defaultEntriesLimit };
+const defaultFilters = { duplicate: true, order: false, limit: defaultEntriesLimit, visibility: 'global' };
 
 /**
  * Filters for emote database requests
@@ -79,6 +85,7 @@ const defaultFilters = { duplicate: true, order: false, limit: defaultEntriesLim
  * @property {boolean} order true if the ordering should be ascending
  * @property {number} limit The number of entries displayed
  * @property {number} since Results from messages after that message id will be kept
+ * @property {string} visibility The criteria for keeping emote entries
  */
 
 module.exports = {
@@ -114,9 +121,10 @@ If you do not provide a filter for either a server or a user and:
             const rawResults = await client.database.fetch(filters, groupBy);
             
             const rawEntries = Object.entries(rawResults);
-            const totalEntries = _.sumBy(rawEntries, x => x[1]);
-            const keyMapBuilder = async keys => await buildKeyMap(keys, filters, groupBy, client);
+            const guild_id = m.channel.guild && m.channel.guild.id;
+            const keyMapBuilder = async keys => await buildKeyMap(keys, filters, groupBy, client, guild_id);
             const entries = await filterEntries(rawEntries, filters, keyMapBuilder);
+            const totalEntries = _.sumBy(entries, x => x[1]);
 
             if (entries.length > 0) {
                 const description = emoteDataToGraph(entries, totalEntries, 5);
@@ -158,9 +166,12 @@ async function filterEntries(entries, filters, keyMapBuilder) {
             entriesToFetch.push(entries[j]);
         }
         const keyMap = await keyMapBuilder(idsToFetch);
-        for (let [rawLabel, value] of entriesToFetch) {
-            const label = keyMap[rawLabel];
-            result.push([label, value]);
+        for (let j = 0; j < entriesToFetch.length && result.length < filters.limit; j++) {
+            const label = keyMap[entriesToFetch[j][0]];
+            const value = entriesToFetch[j][1];
+            if (label !== undefined) {
+                result.push([label, value]);
+            }
         }
     }
     return result;
@@ -179,9 +190,6 @@ function emoteDataToGraph(entries, total, width) {
 
     const maximum = _.maxBy(entries, o => o[1])[1] / width;
     return entries.reduce((result, [label, value]) => {
-        if (label === "undefined") {
-            return `${value}`;
-        }
         const graphBar = "█".repeat(Math.ceil(value / maximum));
         const valuePercent = Math.round(value * totalPercent);
         return result + `${graphBar} ${label} ${valuePercent}% (${value} / ${total})\n`;
@@ -213,9 +221,10 @@ function getGroupByFromFilters(filters) {
  * @param {Filters} filters The filters to define what to do in some specific cases
  * @param {string} groupBy The column used to group the results
  * @param {*} client The client used to find relevant information if necessary
+ * @param {?string} currentGuild_id The current guild's id
  * @returns {{}} The key map
  */
-async function buildKeyMap(keys, filters, groupBy, client) {
+async function buildKeyMap(keys, filters, groupBy, client, currentGuild_id) {
     let mapFunc;
     switch (groupBy) {
         case "user":
@@ -233,12 +242,17 @@ async function buildKeyMap(keys, filters, groupBy, client) {
             mapFunc = key => {
                 const metadata = emotesMetadata[key];
                 if (!metadata) {
-                    return key;
+                    return filters.visibility !== 'server' ? key : undefined;
                 }
                 const { name, animated, guild_id } = metadata;
                 let result = `[${name}](https://cdn.discordapp.com/emojis/${key}.png)`;
                 if (checkEmoteStillInGuild(client, key, guild_id)) {
                     result += ` (<${animated ? "a" : ""}:${name}:${key}>)`;
+                } else if (filters.visibility === 'visible') {
+                    return;
+                }
+                if (filters.visibility === 'server' && (!guild_id || guild_id.toString() !== currentGuild_id)) {
+                    return;
                 }
                 return result;
             };

--- a/lib/commands/emotes.js
+++ b/lib/commands/emotes.js
@@ -1,5 +1,5 @@
 const Constants = require("../core/Constants");
-const { defaultEntriesLimit, maxEntriesLimit, prefix } = require("../../config/config.json");
+const { defaultEntriesLimit, maxEntriesLimit, prefix, developerIDs } = require("../../config/config.json");
 const _ = require("lodash");
 const logger = require("../core/Logger.js");
 const { timestampFromId, dehumanizeTime } = require("../core/Utils");
@@ -9,6 +9,7 @@ const filterRegexes = {
         regexes: [
             { regex: /(?:server|guild):([1-9][0-9]{0,19})/ig, onMatch: match => match[1] },
             { regex: /(?:server|guild):here/ig, onMatch: match => "here" },
+            { regex: /(?:server|guild):all/ig, onMatch: match => "all" },
         ],
     },
     user: {
@@ -110,7 +111,7 @@ If you do not provide a filter for either a server or a user and:
     run: async function(client, m, args) {
         let response;
         const filters = parseFilters(args);
-        if (!filters) {
+        if (!filters || (filters.guild && filters.guild.includes('all') && !developerIDs.includes(m.author.id))) {
             response = `Invalid filter${args.length === 1 ? '' : 's'}`;
         } else {
             fixFilters(filters, m);
@@ -315,6 +316,10 @@ function fixFilters(filters, message) {
         } else {
             filters.user = [ message.author.id ];
         }
+    }
+    
+    if (filters.guild && filters.guild.includes("all")) {
+        delete filters.guild;
     }
 }
 

--- a/lib/commands/emotes.js
+++ b/lib/commands/emotes.js
@@ -2,6 +2,7 @@ const Constants = require("../core/Constants");
 const { defaultEntriesLimit, maxEntriesLimit, prefix } = require("../../config/config.json");
 const _ = require("lodash");
 const logger = require("../core/Logger.js");
+const { timestampFromId } = require("../core/Utils");
 const filterRegexes = {
     guild: {
         multiple: true,
@@ -51,6 +52,12 @@ const filterRegexes = {
             },
         ],
     },
+    since: {
+        multiple: false,
+        regexes: [
+            { regex: /since:([1-9][0-9]{0,19})/g, onMatch: match => Math.floor(timestampFromId(match[1])) },
+        ],
+    },
 };
 const defaultFilters = { duplicate: true, order: false, limit: defaultEntriesLimit };
 
@@ -63,6 +70,7 @@ const defaultFilters = { duplicate: true, order: false, limit: defaultEntriesLim
  * @property {boolean} duplicate false if multiple emotes in the same message should count as 1
  * @property {boolean} order true if the ordering should be ascending
  * @property {number} limit The number of entries displayed
+ * @property {number} since Results from messages after that message id will be kept
  */
 
 module.exports = {

--- a/lib/commands/emotes.js
+++ b/lib/commands/emotes.js
@@ -7,24 +7,24 @@ const filterRegexes = {
     guild: {
         multiple: true,
         regexes: [
-            { regex: /server:([1-9][0-9]{0,19})/g, onMatch: match => match[1] },
-            { regex: /server:here/g, onMatch: match => "here" },
-            { regex: /guild:([1-9][0-9]{0,19})/g, onMatch: match => match[1] },
-            { regex: /guild:here/g, onMatch: match => "here" },
+            { regex: /server:([1-9][0-9]{0,19})/ig, onMatch: match => match[1] },
+            { regex: /server:here/ig, onMatch: match => "here" },
+            { regex: /guild:([1-9][0-9]{0,19})/ig, onMatch: match => match[1] },
+            { regex: /guild:here/ig, onMatch: match => "here" },
         ],
     },
     user: {
         multiple: true,
         regexes: [
-            { regex: /user:([1-9][0-9]{0,19})/g, onMatch: match => match[1] },
-            { regex: /user:me/g, onMatch: match => "me" },
-            { regex: /<@!?([1-9][0-9]{0,19})>/g, onMatch: match => match[1] },
+            { regex: /user:([1-9][0-9]{0,19})/ig, onMatch: match => match[1] },
+            { regex: /user:me/ig, onMatch: match => "me" },
+            { regex: /<@!?([1-9][0-9]{0,19})>/ig, onMatch: match => match[1] },
         ],
     },
     emote: {
         multiple: true,
         regexes: [
-            { regex: /emote:([1-9][0-9]{0,19})/g, onMatch: match => match[1] },
+            { regex: /emote:([1-9][0-9]{0,19})/ig, onMatch: match => match[1] },
             { regex: Constants.CUSTOM_REGEX, onMatch: match => match[3] },
             { regex: new RegExp(`(${Constants.UNICODE_REGEX.source})`, "ug"), onMatch: match => match[2] ? undefined : match[1] },
         ],
@@ -32,19 +32,19 @@ const filterRegexes = {
     duplicate: {
         multiple: false,
         regexes: [
-            { regex: /duplicate:(no?|ye?s?)/g, onMatch: match => match[1].startsWith("n") ? false : true },
+            { regex: /duplicate:(no?|ye?s?)/ig, onMatch: match => match[1].toLowerCase().startsWith("n") ? false : true },
         ],
     },
     order: {
         multiple: false,
         regexes: [
-            { regex: /order:(as?c?e?n?d?i?n?g?|de?s?c?e?n?d?i?n?g?)/g, onMatch: match => match[1].startsWith("a") ? true : false },
+            { regex: /order:(as?c?e?n?d?i?n?g?|de?s?c?e?n?d?i?n?g?)/ig, onMatch: match => match[1].toLowerCase().startsWith("a") ? true : false },
         ],
     },
     limit: {
         multiple: false,
         regexes: [
-            { regex: /limit:([1-9][0-9]*)/g, onMatch: match => {
+            { regex: /limit:([1-9][0-9]*)/ig, onMatch: match => {
                     const n = parseInt(match[1]);
                     if (n > maxEntriesLimit) return;
                     return n;
@@ -55,9 +55,9 @@ const filterRegexes = {
     since: {
         multiple: false,
         regexes: [
-            { regex: /since:([1-9][0-9]{0,19})/g, onMatch: match => Math.floor(timestampFromId(match[1])) },
-            { regex: /last:(\d+\w+)/g, onMatch: match => {
-                    const n = dehumanizeTime(match[1]);
+            { regex: /since:([1-9][0-9]{0,19})/ig, onMatch: match => Math.floor(timestampFromId(match[1])) },
+            { regex: /last:(\d+\w+)/ig, onMatch: match => {
+                    const n = dehumanizeTime(match[1].toLowerCase());
                     if (n < 0) return;
                     const result = Date.now() - n;
                     if (result < 1420070400000) return; // 1420070400000 is the Discord epoch
@@ -69,7 +69,7 @@ const filterRegexes = {
     visibility: {
         multiple: false,
         regexes: [
-            { regex: /visibility:(global|visible|server)/g, onMatch: match => match[1] },
+            { regex: /visibility:(global|visible|server)/ig, onMatch: match => match[1].toLowerCase() },
         ],
     },
 };

--- a/lib/commands/emotes.js
+++ b/lib/commands/emotes.js
@@ -31,15 +31,26 @@ const filterRegexes = {
     duplicate: {
         multiple: false,
         regexes: [
-            { regex: /duplicate:(no?|ye?s?)/, onMatch: match => match[1] && match[1].startsWith("n") ? false : true },
+            { regex: /duplicate:(no?|ye?s?)/g, onMatch: match => match[1] && match[1].startsWith("n") ? false : true },
+        ],
+    },
+    order: {
+        multiple: false,
+        regexes: [
+            { regex: /order:(as?c?e?n?d?i?n?g?|de?s?c?e?n?d?i?n?g?)/g, onMatch: match => match[1] && match[1].startsWith("a") ? true : false },
         ],
     },
 };
-const defaultFilters = { duplicate: true };
+const defaultFilters = { duplicate: true, order: false };
 
 /**
  * Filters for emote database requests
- * @typedef {{user: ?string[], guild: ?string[], emote: ?string[], duplicate: boolean}} Filters
+ * @typedef {Object} Filters
+ * @property {?string[]} user The list of users to keep in the results
+ * @property {?string[]} guild The list of guilds to keep in the results
+ * @property {?string[]} emote The list of emotes to keep in the results
+ * @property {boolean} duplicate false if multiple emotes in the same message should count as 1
+ * @property {boolean} order true if the ordering should be ascending
  */
 
 module.exports = {
@@ -61,6 +72,7 @@ __**Available filters**__
     You can also directly use any emote, custom or not, to filter by it
         Example: \`🤔 :emote:\` (assuming you have access to an emote named 'emote')
     \`duplicate:no\` --> doesn't count duplicate emotes in messages
+    \`order:ascending\` --> put the least used emotes on top instead of bottom
 
 Using multiple filters of the same category will keep any of the given values.
     Example: \`user:me @Someone#1234\` --> entries for me or Someone#1234
@@ -95,7 +107,11 @@ If you do not provide a filter for either a server or a user and:
             
             const entries = Object.entries(rawResults);
             const totalEntries = _.sumBy(entries, x => x[1]);
-            entries.sort((a, b) => b[1] - a[1]);
+            if (filters.order) {
+                entries.sort((a, b) => a[1] - b[1]);
+            } else {
+                entries.sort((a, b) => b[1] - a[1]);
+            }
             entries.splice(topNEntries);
 
             if (entries.length > 0) {
@@ -128,7 +144,7 @@ If you do not provide a filter for either a server or a user and:
 function emoteDataToGraph(entries, total, labelMap, width) {
     const totalPercent = 100 / total;
 
-    const maximum = entries[0][1] / width;
+    const maximum = _.maxBy(entries, o => o[1])[1] / width;
     return entries.reduce((result, [rawLabel, value]) => {
         const label = labelMap[rawLabel];
         if (label === "undefined") {

--- a/lib/commands/emotes.js
+++ b/lib/commands/emotes.js
@@ -113,19 +113,13 @@ If you do not provide a filter for either a server or a user and:
 
             const rawResults = await client.database.fetch(filters, groupBy);
             
-            const entries = Object.entries(rawResults);
-            const totalEntries = _.sumBy(entries, x => x[1]);
-            if (filters.order) {
-                entries.sort((a, b) => a[1] - b[1]);
-            } else {
-                entries.sort((a, b) => b[1] - a[1]);
-            }
-            entries.splice(filters.limit);
+            const rawEntries = Object.entries(rawResults);
+            const totalEntries = _.sumBy(rawEntries, x => x[1]);
+            const keyMapBuilder = async keys => await buildKeyMap(keys, filters, groupBy, client);
+            const entries = await filterEntries(rawEntries, filters, keyMapBuilder);
 
             if (entries.length > 0) {
-                const keys = entries.map(x => x[0]);
-                const keyMap = await buildKeyMap(keys, groupBy, client);
-                const description = emoteDataToGraph(entries, totalEntries, keyMap, 5);
+                const description = emoteDataToGraph(entries, totalEntries, 5);
                 
                 embed = { title: "Results", color: 0x00ff00, description };
                 if (groupBy === "emote") {
@@ -141,20 +135,50 @@ If you do not provide a filter for either a server or a user and:
 }
 
 /**
+ * Filters entries depending on the given specified filters
+ * Note: The given entries will be modified, but will not contain the result
+ * 
+ * @param {[][]} entries An array of [label, value] to filter
+ * @param {Filters} filters The filters
+ * @param {function} keyMapBuilder A function taking a list of keys and returns the keyMap for those keys
+ * @returns {[][]} The resulting filtered entries
+ */
+async function filterEntries(entries, filters, keyMapBuilder) {
+    if (filters.order) {
+        entries.sort((a, b) => a[1] - b[1]);
+    } else {
+        entries.sort((a, b) => b[1] - a[1]);
+    }
+    const result = [];
+    for (let i = 0; result.length < filters.limit && i < entries.length; i += filters.limit) {
+        const idsToFetch = [];
+        const entriesToFetch = [];
+        for (let j = i; j < i + filters.limit && j < entries.length; j++) {
+            idsToFetch.push(entries[j][0]);
+            entriesToFetch.push(entries[j]);
+        }
+        const keyMap = await keyMapBuilder(idsToFetch);
+        for (let [rawLabel, value] of entriesToFetch) {
+            const label = keyMap[rawLabel];
+            result.push([label, value]);
+        }
+    }
+    return result;
+}
+
+/**
  * Returns a string containing the entries formatted as a bar graph
  * 
  * @param {[][]} entries An array of [label, value] to display
  * @param {number} total The total value of entries
- * @param {{}} labelMap A map of label --> displayed label
  * @param {number} width The maximum width of the bars
  * @returns {string} The resulting string to be displayed
  */
-function emoteDataToGraph(entries, total, labelMap, width) {
+function emoteDataToGraph(entries, total, width) {
     const totalPercent = 100 / total;
 
     const maximum = _.maxBy(entries, o => o[1])[1] / width;
-    return entries.reduce((result, [rawLabel, value]) => {
-        const label = labelMap[rawLabel];
+    return entries.reduce((result, [label, value]) => {
         if (label === "undefined") {
             return `${value}`;
         }
@@ -186,11 +210,12 @@ function getGroupByFromFilters(filters) {
  * Creates a map to convert keys into displayable strings
  * 
  * @param {string[]} keys Array of keys to use to build the map
+ * @param {Filters} filters The filters to define what to do in some specific cases
  * @param {string} groupBy The column used to group the results
  * @param {*} client The client used to find relevant information if necessary
  * @returns {{}} The key map
  */
-async function buildKeyMap(keys, groupBy, client) {
+async function buildKeyMap(keys, filters, groupBy, client) {
     let mapFunc;
     switch (groupBy) {
         case "user":

--- a/lib/commands/emotes.js
+++ b/lib/commands/emotes.js
@@ -1,5 +1,5 @@
 const Constants = require("../core/Constants");
-const { topNEntries } = require("../../config/config.json");
+const { defaultEntriesLimit, maxEntriesLimit, prefix } = require("../../config/config.json");
 const _ = require("lodash");
 const logger = require("../core/Logger.js");
 const filterRegexes = {
@@ -31,17 +31,28 @@ const filterRegexes = {
     duplicate: {
         multiple: false,
         regexes: [
-            { regex: /duplicate:(no?|ye?s?)/g, onMatch: match => match[1] && match[1].startsWith("n") ? false : true },
+            { regex: /duplicate:(no?|ye?s?)/g, onMatch: match => match[1].startsWith("n") ? false : true },
         ],
     },
     order: {
         multiple: false,
         regexes: [
-            { regex: /order:(as?c?e?n?d?i?n?g?|de?s?c?e?n?d?i?n?g?)/g, onMatch: match => match[1] && match[1].startsWith("a") ? true : false },
+            { regex: /order:(as?c?e?n?d?i?n?g?|de?s?c?e?n?d?i?n?g?)/g, onMatch: match => match[1].startsWith("a") ? true : false },
+        ],
+    },
+    limit: {
+        multiple: false,
+        regexes: [
+            { regex: /limit:([1-9][0-9]*)/g, onMatch: match => {
+                    const n = parseInt(match[1]);
+                    if (n > maxEntriesLimit) return;
+                    return n;
+                }
+            },
         ],
     },
 };
-const defaultFilters = { duplicate: true, order: false };
+const defaultFilters = { duplicate: true, order: false, limit: defaultEntriesLimit };
 
 /**
  * Filters for emote database requests
@@ -51,6 +62,7 @@ const defaultFilters = { duplicate: true, order: false };
  * @property {?string[]} emote The list of emotes to keep in the results
  * @property {boolean} duplicate false if multiple emotes in the same message should count as 1
  * @property {boolean} order true if the ordering should be ascending
+ * @property {number} limit The number of entries displayed
  */
 
 module.exports = {
@@ -63,31 +75,11 @@ module.exports = {
     longDescription: `Filters will remove any entry that does not match all of the filters.
 For example, if you send an emote in the server with id 1 and then run the command with \`server:2\`, it will not count that emote in the results.
 
+__**Getting ids**__
+If you don't know how to get ids, you can do \`${prefix}help id\`.
+
 __**Available filters**__
-    \`server:id\` --> \`id\` is the id of a server
-    \`server:here\` --> uses the current server's id if the command is used in a server
-    \`user:id\` --> \`id\` is the id of a user (you can also directly mention a user)
-    \`user:me\` --> uses your id
-    \`emote:id\` --> \`id\` is the id of a custom emote
-    You can also directly use any emote, custom or not, to filter by it
-        Example: \`🤔 :emote:\` (assuming you have access to an emote named 'emote')
-    \`duplicate:no\` --> doesn't count duplicate emotes in messages
-    \`order:ascending\` --> put the least used emotes on top instead of bottom
-
-Using multiple filters of the same category will keep any of the given values.
-    Example: \`user:me @Someone#1234\` --> entries for me or Someone#1234
-    Example: \`🤔 👌\` --> entries for 🤔 or 👌
-    Example: \`server:here user:me 🤔 👌\` --> my entries for 🤔 or 👌 in the server
-
-__**How to get ids**__
-To get a custom emote's id, send it with a \\ in front.
-    Example: \`\\:myemote:\` --> \`<:myemote:id>\` (\`id\` is a long number)
-To get a user's id, you can mention them with a \\ in front (won't notify).
-    Example: \`\\@Someone#1234\` --> \`<@id>\` (\`id\` is a long number)
-To get a server's id, enable Settings > Appearance > Advanced > Developer Mode.
-    Once that's done, right click (or hold on mobile) a server > Copy ID.
-Note: You can also use the developer mode to get a user's id.
-    If you do that, be careful not to copy a message's id.
+For more information about the filters, you can do \`${prefix}filters\`.
 
 __**Default filters**__
 If you do not provide a filter for either a server or a user and:
@@ -112,7 +104,7 @@ If you do not provide a filter for either a server or a user and:
             } else {
                 entries.sort((a, b) => b[1] - a[1]);
             }
-            entries.splice(topNEntries);
+            entries.splice(filters.limit);
 
             if (entries.length > 0) {
                 const keys = entries.map(x => x[0]);

--- a/lib/commands/filters.js
+++ b/lib/commands/filters.js
@@ -19,6 +19,7 @@ module.exports = {
     \`duplicate:no\` --> doesn't count duplicate emotes in messages
     \`order:ascending\` --> put the least used emotes on top instead of bottom
     \`limit:n\` --> displays **n** results (defaults to ${defaultEntriesLimit})
+    \`since:id\` --> keeps entries from messages sent since the message with id \`id\`
 
 Using multiple filters of the same category will keep any of the given values.
 This currently only applies to the server, user, and emote filters.

--- a/lib/commands/filters.js
+++ b/lib/commands/filters.js
@@ -23,6 +23,10 @@ module.exports = {
     \`last:time\` --> keeps entries from messages sent in the last \`time\`
         Example: \`last:2mo3w4d\` for the last 2 months, 3 weeks, and 4 days
         \`time\`'s units can be: ms, s, m, h, d, w, mo, or y
+    \`visibility:value\` --> \`value\` can be one of global, visible, and server
+        If value is server, it will only keep custom emotes from that server
+        If value is visible, it will only keep emotes visible by the bot
+        Otherwise, it will display all emotes regardless of being visible or not
 
 Using multiple filters of the same category will keep any of the given values.
 This currently only applies to the server, user, and emote filters.

--- a/lib/commands/filters.js
+++ b/lib/commands/filters.js
@@ -1,0 +1,29 @@
+const { defaultEntriesLimit } = require('../../config/config.json');
+
+module.exports = {
+    permissions: [],
+    guildOnly: false,
+    cooldown: 45000,
+    shortDescription: 'Posts information about filters',
+    longDescription: '*In case you\'re wondering why it isn\'t in here, it\'s because of its size.*',
+    run: async function(client, m, args) {
+        await m.channel.createMessage(`
+**Available filters**
+    \`server:id\` --> \`id\` is the id of a server
+    \`server:here\` --> uses the current server's id if the command is used in a server
+    \`user:id\` --> \`id\` is the id of a user (you can also directly mention a user)
+    \`user:me\` --> uses your id
+    \`emote:id\` --> \`id\` is the id of a custom emote
+    You can also directly use any emote, custom or not, to filter by it
+        Example: \`🤔 :emote:\` (assuming you have access to an emote named 'emote')
+    \`duplicate:no\` --> doesn't count duplicate emotes in messages
+    \`order:ascending\` --> put the least used emotes on top instead of bottom
+    \`limit:n\` --> displays **n** results (defaults to ${defaultEntriesLimit})
+
+Using multiple filters of the same category will keep any of the given values.
+This currently only applies to the server, user, and emote filters.
+    Example: \`user:me @Someone#1234\` --> entries for me or Someone#1234
+    Example: \`🤔 👌\` --> entries for 🤔 or 👌
+    Example: \`server:here user:me 🤔 👌\` --> my entries for 🤔 or 👌 in the server`);
+    }
+}

--- a/lib/commands/filters.js
+++ b/lib/commands/filters.js
@@ -20,6 +20,9 @@ module.exports = {
     \`order:ascending\` --> put the least used emotes on top instead of bottom
     \`limit:n\` --> displays **n** results (defaults to ${defaultEntriesLimit})
     \`since:id\` --> keeps entries from messages sent since the message with id \`id\`
+    \`last:time\` --> keeps entries from messages sent in the last \`time\`
+        Example: \`last:2mo3w4d\` for the last 2 months, 3 weeks, and 4 days
+        \`time\`'s units can be: ms, s, m, h, d, w, mo, or y
 
 Using multiple filters of the same category will keep any of the given values.
 This currently only applies to the server, user, and emote filters.

--- a/lib/commands/id.js
+++ b/lib/commands/id.js
@@ -1,0 +1,20 @@
+const idTutorial = `To get a custom emote's id, send it with a \\ in front.
+    Example: \`\\:myemote:\` --> \`<:myemote:id>\` (\`id\` is a long number)
+To get a user's id, you can mention them with a \\ in front (won't notify).
+    Example: \`\\@Someone#1234\` --> \`<@id>\` (\`id\` is a long number)
+To get a server's id, enable Settings > Appearance > Advanced > Developer Mode.
+    Once that's done, right click (or hold on mobile) a server > Copy ID.
+Note: You can also use the developer mode to get a user's id.
+    If you do that, be careful not to copy a message's id.`;
+
+module.exports = {
+    permissions: [],
+    guildOnly: false,
+    cooldown: 5000,
+    hidden: true,
+    shortDescription: 'How to get ids',
+    longDescription: idTutorial,
+    run: async function(client, m, args) {
+        await m.channel.createMessage(idTutorial);
+    }
+}

--- a/lib/core/Utils.js
+++ b/lib/core/Utils.js
@@ -79,6 +79,41 @@ module.exports.humanizeTime = (timeMs) => {
     return times.slice(0, 2).join(" ");
 };
 
+const DEHUMANIZE_TIME_CONSTANTS = [
+    { name: 'y', fraction: 12 },
+    { name: 'mo', fraction: 4 },
+    { name: 'w', fraction: 7 },
+    { name: 'd', fraction: 24 },
+    { name: 'h', fraction: 60 },
+    { name: 'm', fraction: 60 },
+    { name: 's', fraction: 1000 },
+    { name: 'ms', fraction: 1 },
+];
+/**
+ * Converts a human readable string into milliseconds
+ * Examples: 1m --> 60000; 3d1h --> 262800000
+ *
+ * @param {string} timeMs A human readable string to convert
+ * @returns {number} The total number of milliseconds. Will be -1 if it fails to parse.
+ */
+module.exports.dehumanizeTime = (timeString) => {
+    let result = 0;
+    const regex = /([1-9][0-9]*)(ms|s|h|d|w|mo|y|m)/ig;
+    let match;
+    let hasMatched = false;
+    const specifiedTime = {};
+    while ((match = regex.exec(timeString)) !== null) {
+        hasMatched = true;
+        specifiedTime[match[2]] = parseInt(match[1]);
+    }
+    const shouldInvert = !hasMatched || regex.lastIndex !== 0;
+    for (let { name, fraction } of DEHUMANIZE_TIME_CONSTANTS) {
+        result += specifiedTime[name] || 0;
+        result *= fraction;
+    }
+    return shouldInvert ? -1 : result;
+};
+
 let bashColors = {
     none: "\033[0m",
     black: "\033[0;30m",

--- a/lib/core/Utils.js
+++ b/lib/core/Utils.js
@@ -23,13 +23,14 @@ function groupResultsBy(objects, keyColumn) {
  * @param {{}[]} objects An array of objects to group
  * @param {string} groupBy The column to use for grouping
  * @param {string} sumBy The column to use for summing
+ * @param {boolean?} shouldCount true if it should count instead of summing by the sumBy column
  * @returns {{}} The grouped object
  */
-function groupSumResultsBy(objects, groupBy, sumBy) {
+function groupSumResultsBy(objects, groupBy, sumBy, shouldCount) {
     return objects.reduce((acc, current) => {
         const key = current[groupBy];
         acc[key] = acc[key] || 0;
-        acc[key] += current[sumBy] || 0;
+        acc[key] += shouldCount ? 1 : current[sumBy] || 0;
         return acc;
     }, {});
 }

--- a/lib/core/db/Cassandra.js
+++ b/lib/core/db/Cassandra.js
@@ -106,7 +106,7 @@ class Cassandra {
 
         const { rows } = await this.execute(query, params);
 
-        return groupSumResultsBy(rows, groupColumn, queries.emoteUsagesColumn);
+        return groupSumResultsBy(rows, groupColumn, queries.emoteUsagesColumn, !filters.duplicate);
     }
 
     async getEmoteMetadata(emote_ids) {

--- a/lib/core/db/CassandraQueries.js
+++ b/lib/core/db/CassandraQueries.js
@@ -105,6 +105,7 @@ queries.filters = {
     guild: " guild_id IN ? ",
     user: " user_id IN ? ",
     emote: " emote_id IN ? ",
+    since: " sent_at > ? ",
 };
 queries.parseFilters = (filters) => {
     const filterEntries = Object.entries(_.pick(filters, Object.keys(queries.filters)));

--- a/lib/core/db/CassandraQueries.js
+++ b/lib/core/db/CassandraQueries.js
@@ -1,3 +1,4 @@
+const _ = require("lodash");
 const queries = {};
 
 queries.createTables = [
@@ -96,7 +97,7 @@ queries.insertEmote = " INSERT INTO emotes "
     + " VALUES "
     + " (?, ?, ?, ?, ?); ";
 queries.deleteEmotes = " DELETE FROM emotes WHERE guild_id = ? AND user_id = ? AND sent_at = ?; ";
-queries.getData = " SELECT * FROM emotes ";
+queries.getData = " SELECT guild_id, user_id, emote_id, sent_at, usages FROM emotes ";
 queries.filtersPrefix = " WHERE ";
 queries.filtersSeparator = " AND ";
 queries.filtersSuffix = " ALLOW FILTERING ; ";
@@ -106,7 +107,7 @@ queries.filters = {
     emote: " emote_id IN ? ",
 };
 queries.parseFilters = (filters) => {
-    const filterEntries = Object.entries(filters);
+    const filterEntries = Object.entries(_.pick(filters, Object.keys(queries.filters)));
     const params = [];
     let query = queries.getData;
     if (filterEntries.length > 0) {

--- a/lib/core/db/PostgreSQL.js
+++ b/lib/core/db/PostgreSQL.js
@@ -105,7 +105,7 @@ class PostgreSQL {
 
         const { rows } = await this.execute(query, params);
 
-        return groupSumResultsBy(rows, groupColumn, queries.emoteUsagesColumn);
+        return groupSumResultsBy(rows, groupColumn, queries.emoteUsagesColumn, !filters.duplicate);
     }
 
     async getEmoteMetadata(emote_ids) {

--- a/lib/core/db/PostgreSQLQueries.js
+++ b/lib/core/db/PostgreSQLQueries.js
@@ -1,3 +1,4 @@
+const _ = require("lodash");
 const queries = {};
 
 queries.createTables = [
@@ -107,7 +108,7 @@ queries.insertEmote = " INSERT INTO emotes "
     + " ($1, $2, $3, $4, $5) "
     + " ON CONFLICT (guild_id, user_id, emote_id, sent_at) DO UPDATE SET usages = EXCLUDED.usages; ";
 queries.deleteEmotes = " DELETE FROM emotes WHERE guild_id = $1 AND user_id = $2 AND sent_at = $3; ";
-queries.getData = " SELECT * FROM emotes ";
+queries.getData = " SELECT guild_id, user_id, emote_id, sent_at, usages FROM emotes ";
 queries.filtersPrefix = " WHERE ";
 queries.filtersSeparator = " AND ";
 queries.filtersSuffix = " ; ";
@@ -117,7 +118,7 @@ queries.filters = {
     emote: " emote_id = ANY($",
 };
 queries.parseFilters = (filters) => {
-    const filterEntries = Object.entries(filters);
+    const filterEntries = Object.entries(_.pick(filters, Object.keys(queries.filters)));
     const params = [];
     let query = queries.getData;
     if (filterEntries.length > 0) {

--- a/lib/core/db/PostgreSQLQueries.js
+++ b/lib/core/db/PostgreSQLQueries.js
@@ -113,9 +113,10 @@ queries.filtersPrefix = " WHERE ";
 queries.filtersSeparator = " AND ";
 queries.filtersSuffix = " ; ";
 queries.filters = {
-    guild: " guild_id = ANY($",
-    user: " user_id = ANY($",
-    emote: " emote_id = ANY($",
+    guild: " guild_id = ANY($<number>)",
+    user: " user_id = ANY($<number>)",
+    emote: " emote_id = ANY($<number>)",
+    since: " sent_at > $<number> ",
 };
 queries.parseFilters = (filters) => {
     const filterEntries = Object.entries(_.pick(filters, Object.keys(queries.filters)));
@@ -126,7 +127,7 @@ queries.parseFilters = (filters) => {
     }
     const filterQueries = [];
     for (let [filter, value] of filterEntries) {
-        filterQueries.push(queries.filters[filter] + (filterQueries.length + 1) + ")");
+        filterQueries.push(queries.filters[filter].replace('<number>', filterQueries.length + 1));
         params.push(value);
     }
     query += filterQueries.join(queries.filtersSeparator);


### PR DESCRIPTION
This PR adds the following filters:
- `server:all` for devs only
- `limit:n`
- `since:id` and `last:time`
- `duplicate:no`
- `sort:ascending`
- `visibility:value`

This also adds a filter summary in `[p]emotes`'s response and cleans up the `[p]help emotes` by moving some parts into different commands (`[p]id` and `[p]filters`).