### PR TITLE
Updating channels when the bot's roles change

### DIFF
--- a/lib/Background.js
+++ b/lib/Background.js
@@ -27,6 +27,7 @@ class Background {
         this.client.on("messageUpdate", this.onMessageUpdate.bind(this));
         this.client.on("channelCreate", this.onChannelCreate.bind(this));
         this.client.on("channelUpdate", this.onChannelUpdate.bind(this));
+        this.client.on("guildMemberUpdate", this.onGuildMemberUpdate.bind(this));
         this.client.on("guildCreate", guild => this.initializeGuilds([ guild ]));
         this.bucket = new Eris.Bucket(Infinity, 0);
         this.backfilledChannels = new Set();
@@ -167,6 +168,13 @@ class Background {
 
         const c = await this.database.fetchChannels([ channel.id ]);
         this.queueChannelFromDatabase(c[0]);
+    }
+
+    async onGuildMemberUpdate(guild, member, oldMember) {
+        if (member.id !== this.client.user.id) return;
+        if (member.roles.length === oldMember.roles.length) return;
+
+        await this.initializeGuilds([ guild ]);
     }
 
     onReady() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-emote-count",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Discord bot for tracking emote statistics in Discord servers.",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-emote-count",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A Discord bot for tracking emote statistics in Discord servers.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Everything is in the title.

It now starts backfilling the whole guild whenever its roles change in that guild.