### PR TITLE
Fix log messages being sent multiple times

### DIFF
--- a/lib/Background.js
+++ b/lib/Background.js
@@ -22,6 +22,7 @@ class Background {
         this.client.on("warn", e => logger.warn(e));
         this.client.on("debug", e => logger.debug(e));
         
+        this.client.once("ready", this.setupLogs.bind(this));
         this.client.on("ready", this.onReady.bind(this));
         this.client.on("messageCreate", this.onMessageCreate.bind(this));
         this.client.on("messageUpdate", this.onMessageUpdate.bind(this));
@@ -177,7 +178,7 @@ class Background {
         await this.initializeGuilds([ guild ]);
     }
 
-    onReady() {
+    setupLogs() {
         let logChannel = this.client.getChannel(config.logChannel || "ErisIsQuality");
         if(logChannel) {
             logger.debug("Detected channel to log background client messages to.");
@@ -185,7 +186,9 @@ class Background {
 
             logger.registerListener("info", this.onLogMessage.bind(this));
         }
+    }
 
+    onReady() {
         logger.info(lightGreen + "Background Ready!" + none);
         if (process.env.NO_BACKFILLING === "true") return;
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -20,6 +20,7 @@ class Client {
         this.client.on("warn", e => logger.warn(e));
         this.client.on("debug", e => logger.debug(e));
 
+        this.client.once("ready", this.setupLogs.bind(this));
         this.client.on("ready", this.onReady.bind(this));
         this.client.on("messageCreate", this.onMessageCreate.bind(this));
         const onDelete = this.onMessageDelete.bind(this);
@@ -80,7 +81,7 @@ class Client {
         }
     }
 
-    async onReady() {
+    setupLogs() {
         let logChannel = this.client.getChannel(config.logChannel || "ErisIsQuality");
         if(logChannel) {
             logger.debug("Detected channel to log client messages to.");
@@ -88,7 +89,9 @@ class Client {
 
             logger.registerListener("info", this.onLogMessage.bind(this));
         }
+    }
 
+    async onReady() {
         logger.info(lightGreen + "Ready!" + none);
 
         const rawGuild_ids = await this.database.fetchGuilds();


### PR DESCRIPTION
**Cause**: The `ready` handler registered a listener that instructed the ChannelLogger to log to a channel. It's possible for `ready` to be received multiple times, in the event that the bot is unable to `resume` properly. This caused multiple listeners to be registered.

**Fix**: Move Logger logic to its own handler that only ever runs once.